### PR TITLE
RSDK-3114: Only fail creating a client when all options fail, rather than any option failing.

### DIFF
--- a/client.go
+++ b/client.go
@@ -229,7 +229,7 @@ func newClient(
 	}
 
 	if opts.listenOn == IPv4AndIPv6 && ipv4conn == nil && ipv6conn == nil {
-		return nil, fmt.Errorf("Failed to listen on a socket. Error: %w", multierr.Combine(ipv4Err, ipv6Err))
+		return nil, fmt.Errorf("failed to listen on a socket; error: %w", multierr.Combine(ipv4Err, ipv6Err))
 	}
 
 	inboundBufferSize := 0

--- a/client.go
+++ b/client.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cenkalti/backoff"
 	"github.com/edaniels/golog"
 	"github.com/miekg/dns"
+	"go.uber.org/multierr"
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
 )
@@ -210,22 +211,25 @@ func newClient(
 	// IPv4 interfaces
 	var ipv4conn *ipv4.PacketConn
 	var ipv4Ifaces []net.Interface
+	var ipv4Err, ipv6Err error
 	if (opts.listenOn & IPv4) > 0 {
-		var err error
-		ipv4conn, ipv4Ifaces, err = joinUdp4Multicast(ifaces)
-		if err != nil {
-			return nil, err
+		ipv4conn, ipv4Ifaces, ipv4Err = joinUdp4Multicast(ifaces)
+		if opts.listenOn == IPv4 && ipv4Err != nil {
+			return nil, ipv4Err
 		}
 	}
 	// IPv6 interfaces
 	var ipv6conn *ipv6.PacketConn
 	var ipv6Ifaces []net.Interface
 	if (opts.listenOn & IPv6) > 0 {
-		var err error
-		ipv6conn, ipv6Ifaces, err = joinUdp6Multicast(ifaces)
-		if err != nil {
-			return nil, err
+		ipv6conn, ipv6Ifaces, ipv6Err = joinUdp6Multicast(ifaces)
+		if opts.listenOn == IPv6 && ipv6Err != nil {
+			return nil, ipv6Err
 		}
+	}
+
+	if opts.listenOn == IPv4AndIPv6 && ipv4conn == nil && ipv6conn == nil {
+		return nil, fmt.Errorf("Failed to listen on a socket. Error: %w", multierr.Combine(ipv4Err, ipv6Err))
 	}
 
 	inboundBufferSize := 0

--- a/go.mod
+++ b/go.mod
@@ -9,3 +9,5 @@ require (
 	github.com/pkg/errors v0.9.1
 	golang.org/x/net v0.0.0-20210423184538-5f58ad60dda6
 )
+
+require go.uber.org/multierr v1.6.0


### PR DESCRIPTION
A `client` for a `Resolver` can be configured to listen on either ipv4 or ipv6. When a client is configured this way, only one of ipv4 or ipv6 is now necessary for construction to be a success.